### PR TITLE
Added tutorial CLI03 - document collections

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -27,6 +27,7 @@ parts:
     sections:
       - file: cli/01_connect_gdn(CLI)
       - file: cli/02_key_value_store(CLI)
+      - file: cli/03_docs_store(CLI)
       - file: cli/05_graph_traversals(CLI)
       - file: cli/06_building_restql_apis(CLI)
 - caption: Advanced

--- a/cli/03_docs_store(CLI).ipynb
+++ b/cli/03_docs_store(CLI).ipynb
@@ -1,0 +1,104 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f63d4ffe",
+   "metadata": {},
+   "source": [
+    "# CLI03 - Quick Start with Documents Store\n",
+    "\n",
+    "The GDN CLI has limited support for working with document based collections, however additional capabilities are on the roadmap.\n",
+    "\n",
+    "Presently, document collections can be mainulated at the collection level but individual documents are not accessible."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "744bf99b",
+   "metadata": {},
+   "source": [
+    "## 1. Get GeoFabric Details\n",
+    "\n",
+    "List the available GeoFabrics and display metadata on the _system fabric by running the following commands."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f18c767d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gdnsl fabric list\n",
+    "gdnsl fabric describe _system"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b678fd8e",
+   "metadata": {},
+   "source": [
+    "## 2. Create Collection\n",
+    "\n",
+    "Create a collection called employees by running the following command."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f856c722",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gdnsl collection create employees"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "62216d82",
+   "metadata": {},
+   "source": [
+    "## 3. Describe Collection\n",
+    "\n",
+    "Display collection metadata by running the following command."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f0094fa7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gdnsl collection describe employees"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eba04413",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "## Section Completed!"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Bash",
+   "language": "bash",
+   "name": "bash"
+  },
+  "language_info": {
+   "codemirror_mode": "shell",
+   "file_extension": ".sh",
+   "mimetype": "text/x-sh",
+   "name": "bash"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This tutorial does not include all of the steps as the Python and JS tutorials because the CLI does not support working with individual documents. Also, I'm not sure if it makes sense to keep the GeoFabrics as the first step since it feels orthogonal.